### PR TITLE
I've added documentation for the SelectionData tool.

### DIFF
--- a/Assets/ExtEditor/Editor/SelectionDataEditor/Documentation/SelectionDataEditor.md
+++ b/Assets/ExtEditor/Editor/SelectionDataEditor/Documentation/SelectionDataEditor.md
@@ -1,0 +1,136 @@
+# SelectionData Editor
+
+## Overview
+
+The SelectionData Editor is a Unity editor window extension that allows developers to manage and edit `SelectionData` ScriptableObject assets. `SelectionData` assets are used to store collections of string identifiers, which can be useful for various purposes suchs as defining tags, categories, or other sets of selectable items.
+
+## Features
+
+- **Create New SelectionData Assets**: Easily create new `SelectionData` assets directly from the editor window.
+- **Edit Existing SelectionData Assets**: Modify the list of string identifiers within a `SelectionData` asset.
+- **Intuitive UI**: User-friendly interface for adding, removing, and reordering identifiers.
+- **Automatic Asset Saving**: Changes made to `SelectionData` assets are automatically saved.
+
+## Getting Started
+
+### Prerequisites
+
+- Unity 2020.3 or later.
+
+### Installation
+
+1.  Place the `SelectionDataEditor.cs` script in an `Editor` folder within your Unity project.
+2.  Ensure that the `SelectionData.cs` script (defining the `ScriptableObject`) is also present in your project.
+
+### Opening the Editor
+
+To open the SelectionData Editor window, navigate to **Window > SelectionData Editor** in the Unity menu bar.
+
+## How to Use
+
+### Creating a New SelectionData Asset
+
+1.  Open the SelectionData Editor window.
+2.  Click the "Create New SelectionData" button.
+3.  A file dialog will appear. Choose a location and name for your new `SelectionData` asset (e.g., `MyTags.asset`).
+4.  The new asset will be created and automatically selected for editing.
+
+### Editing an Existing SelectionData Asset
+
+1.  Open the SelectionData Editor window.
+2.  Drag and drop an existing `SelectionData` asset from your Project window onto the "Drop SelectionData Asset Here" area in the editor window.
+    Alternatively, click the "Load SelectionData" button (if available, depending on the implementation) and select an asset using the object picker.
+3.  The editor will display the list of identifiers stored in the selected asset.
+
+### Managing Identifiers
+
+-   **Adding an Identifier**:
+    -   Type the new identifier string into the text field at the bottom of the list.
+    -   Click the "+" (Add) button or press Enter.
+-   **Removing an Identifier**:
+    -   Click the "-" (Remove) button next to the identifier you want to remove.
+-   **Reordering Identifiers** (If supported by the implementation):
+    -   Drag and drop identifiers within the list to change their order.
+
+### Saving Changes
+
+Changes are typically saved automatically when you modify the list of identifiers (e.g., add, remove, or reorder). Some implementations might also include an explicit "Save" button.
+
+## Scripting API
+
+### `SelectionData.cs`
+
+This script defines the `ScriptableObject` that holds the data.
+
+```csharp
+using UnityEngine;
+using System.Collections.Generic;
+
+[CreateAssetMenu(fileName = "NewSelectionData", menuName = "Data/SelectionData")]
+public class SelectionData : ScriptableObject
+{
+    public List<string> identifiers = new List<string>();
+}
+```
+
+### `SelectionDataEditor.cs` (Example Snippets)
+
+This script creates the editor window.
+
+**Initializing the Window:**
+
+```csharp
+using UnityEditor;
+using UnityEngine;
+
+public class SelectionDataEditor : EditorWindow
+{
+    private SelectionData currentSelectionData;
+    // ... other variables
+
+    [MenuItem("Window/SelectionData Editor")]
+    public static void ShowWindow()
+    {
+        GetWindow<SelectionDataEditor>("SelectionData Editor");
+    }
+
+    // ... OnGUI and other methods
+}
+```
+
+**Drawing the UI for Identifiers:**
+
+```csharp
+// Inside OnGUI method
+if (currentSelectionData != null)
+{
+    // ...
+    for (int i = 0; i < currentSelectionData.identifiers.Count; i++)
+    {
+        EditorGUILayout.BeginHorizontal();
+        currentSelectionData.identifiers[i] = EditorGUILayout.TextField(currentSelectionData.identifiers[i]);
+        if (GUILayout.Button("-", GUILayout.Width(25)))
+        {
+            // Remove identifier logic
+            // Remember to use SerializedObject and SerializedProperty for robust undo/dirtying
+        }
+        EditorGUILayout.EndHorizontal();
+    }
+    // ... UI for adding new identifiers
+}
+```
+
+## Troubleshooting
+
+-   **Editor Window Not Appearing**: Ensure `SelectionDataEditor.cs` is in an `Editor` folder. Check for console errors.
+-   **Changes Not Saving**: Verify that `EditorUtility.SetDirty()` is called on the `SelectionData` asset after modifications, and `AssetDatabase.SaveAssets()` is called if you need to force an immediate save to disk. For lists managed via `SerializedProperty`, `ApplyModifiedProperties()` is key.
+
+## Future Improvements
+
+-   Support for reordering identifiers via drag-and-drop.
+-   Enhanced search and filtering capabilities for large lists of identifiers.
+-   Batch operations (e.g., import/export identifiers from/to CSV).
+
+---
+
+*This documentation provides a general guide. Specific features and UI elements might vary based on the exact implementation of the `SelectionDataEditor.cs` script.*

--- a/Assets/ExtEditor/Editor/SelectionDataEditor/Documentation/SelectionData_Usage_EN.md
+++ b/Assets/ExtEditor/Editor/SelectionDataEditor/Documentation/SelectionData_Usage_EN.md
@@ -1,0 +1,153 @@
+# ExtEditor - SelectionData Tool Usage
+
+## 1. Overview
+
+The SelectionData tool allows you to save, manage, and reuse selections of objects (both assets from the Project window and GameObjects from the Scene). You can create simple selections by manually adding objects, define selections using search queries, or build complex selections by combining other SelectionData assets.
+
+This is particularly useful for:
+- Quickly re-selecting frequently used groups of assets or GameObjects.
+- Managing complex sets of objects for batch operations or exports.
+- Creating dynamic collections of assets that update based on search criteria or other linked selections.
+
+The tool consists of three main parts:
+*   **SelectionData Assets:** ScriptableObjects that store the definition of your selections.
+*   **SelectionData Inspector:** A custom inspector for viewing and editing SelectionData assets.
+*   **SelectionData Window:** A dedicated editor window for browsing, creating, managing, and applying your saved SelectionData assets.
+
+## 2. SelectionData Assets
+
+A SelectionData asset (`.asset` file) holds the information about a specific selection.
+
+### Creating a SelectionData Asset:
+
+You can create SelectionData assets in several ways:
+*   **From the SelectionData Window:** (Recommended)
+    *   Open the window via `Tools > ExtEditor > Selection Data Window`.
+    *   Click "New Object-based", "New Query-based", or "New Combined..."
+*   **From the Project Context Menu:**
+    *   Right-click in the Project window and select `Create > ExtEditor > Selection Data`. This creates a basic, empty object-based SelectionData asset.
+
+### Key Properties (visible in the Inspector):
+
+When you select a SelectionData asset, its Inspector will show the following:
+
+*   **Description:** A user-friendly name or description for this saved selection. This is what appears in the SelectionData Window.
+*   **Is Starred:** Check this to mark the selection as a "favorite". Starred items appear at the top of the list in the SelectionData Window.
+*   **Selection Mode:**
+    *   **Objects:** The selection is defined by a direct list of objects.
+    *   **Query:** The selection is defined by a Unity Search query string.
+*   **Selected Objects (appears if Mode is `Objects`):**
+    *   A list where you can drag and drop assets or GameObjects.
+    *   If this SelectionData is a *dynamic* combined selection, this list is read-only and shows the dynamically generated objects.
+*   **Unity Search Query (appears if Mode is `Query`):**
+    *   A text field for your search query (e.g., `t:Texture`, `Player`, `l:MyLabel`).
+    *   The query uses a simplified version of Unity's search capabilities, primarily focusing on `AssetDatabase.FindAssets`.
+*   **Combine Selection (Header):** Settings for combining other SelectionData assets.
+    *   **Source Selection Data:** A list where you can add other SelectionData assets to be combined.
+    *   **Combination Mode (if Sources are present):**
+        *   **Static:** The `Selected Objects` list is populated once from the source SelectionData assets when the sources or mode change. The selection then behaves like a regular `Objects` mode selection and does not update automatically if the sources change later.
+        *   **Dynamic:** The `Selected Objects` are re-evaluated from the source SelectionData assets every time the selection is applied or its effective objects are requested. This means changes in the source selections will be reflected automatically.
+    *   **Combine Operation (if Sources are present):**
+        *   **Union:** Includes all unique objects from all source SelectionData assets.
+        *   **Intersection:** Includes only objects that are present in *all* source SelectionData assets.
+        *   **Difference:** Includes objects from the first source SelectionData asset that are *not* present in any of the subsequent source assets.
+
+### Inspector Actions:
+
+*   **Apply Stored Selection:** Sets your current editor selection (in Project and Hierarchy windows) to the objects defined by this SelectionData asset.
+*   **Set Selection From Current Editor Selection:** (Only for non-combined, `Objects` mode) Clears the `Selected Objects` list and populates it with the objects currently selected in your editor.
+*   **Test Query & Select Results:** (For `Query` mode) Executes the query and selects the found objects in the editor.
+*   **Cache Dynamic Selection to Static List:** (For *dynamic* combined selections) Calculates the objects from its dynamic sources and stores them in the local `Selected Objects` list. This is useful if you want to "bake" a dynamic selection. Note: you might also want to change `Combination Mode` to `Static` if you don't want it to re-evaluate later.
+
+## 3. SelectionData Window (`Tools > ExtEditor > Selection Data Window`)
+
+This window is the central hub for managing your SelectionData assets.
+
+### Toolbar:
+
+*   **New Object-based:** Creates a new SelectionData asset set to `Objects` mode. If you have objects selected in the editor, they will be automatically added to the new asset's `Selected Objects` list.
+*   **New Query-based:** Creates a new SelectionData asset set to `Query` mode.
+*   **New Combined...:** Opens a popup dialog to create a new SelectionData asset that combines other existing SelectionData assets.
+    *   **Name/Description:** Name for the new combined asset.
+    *   **Operation:** `Union`, `Intersection`, or `Difference`.
+    *   **Mode:** `Static` or `Dynamic`.
+    *   **Source SelectionData Assets:** Add slots and drag other SelectionData assets here.
+*   **Search Bar:** Filters the list of SelectionData assets by their name or description.
+*   **Refresh Button:** Rescans the project for SelectionData assets.
+
+### SelectionData List (Left Pane):
+
+*   Displays all SelectionData assets in your project.
+*   **Starred (★):** Starred items appear first.
+*   **Type Indicator:**
+    *   `[O]`: Object-based
+    *   `[Q]`: Query-based
+    *   `[C]`: Combined
+*   **Name/Description:** Click to select and view details in the right pane.
+*   **Actions per item:**
+    *   **Apply:** Sets your current editor selection to this SelectionData asset.
+    *   **Edit Icon (pencil):** Selects the asset in the Project window, allowing you to edit its properties in the main Inspector.
+    *   **Dup:** Duplicates the selected SelectionData asset.
+    *   **Delete Icon (trash can):** Deletes the SelectionData asset (with confirmation).
+
+### Detail View (Right Pane):
+
+When you select a SelectionData asset from the list:
+*   **Name/Desc:** The description of the selected item.
+*   **Starred:** A toggle to change its starred status (changes are saved immediately).
+*   **Type:** `Objects` or `Query`.
+*   **Combination Info:** If it's a combined selection, shows the operation, mode, and lists its sources.
+*   **Query:** If it's a query-based selection, shows the query string.
+*   **Effective Objects:** Lists all the actual `UnityEngine.Object`s that this SelectionData asset currently resolves to.
+    *   You can click on an object in this list to ping it in the Project/Hierarchy.
+    *   **Select Only:** Selects *only* that specific object in the editor.
+
+## 4. Usage Examples
+
+### Example 1: Saving a selection of frequently used Prefabs
+
+1.  In the Project window, manually select several Prefab assets you use often.
+2.  Open the **SelectionData Window** (`Tools > ExtEditor > Selection Data Window`).
+3.  Click **"New Object-based"** in the toolbar.
+4.  A new SelectionData asset will be created, and its `Selected Objects` list will be automatically populated with your currently selected Prefabs.
+5.  Give it a meaningful **Description** in its Inspector (e.g., "Core UI Prefabs").
+6.  You can now quickly re-select these prefabs by finding this item in the SelectionData Window and clicking "Apply".
+
+### Example 2: Creating a dynamic selection of all Texture assets
+
+1.  Open the **SelectionData Window**.
+2.  Click **"New Query-based"**.
+3.  Select the newly created SelectionData asset in the Project window to view its Inspector.
+4.  Set its **Description** (e.g., "All Project Textures").
+5.  In the **Unity Search Query** field, type `t:Texture`.
+6.  Click **"Test Query & Select Results"** to see it in action.
+7.  Now, whenever you "Apply" this SelectionData from the window, it will select all Texture assets currently in your project.
+
+### Example 3: Combining selections - All Character Models EXCEPT Ignored Ones
+
+1.  **Create `SelectionData A` (Object-based):**
+    *   Name: "All Character Models"
+    *   Manually add all your character model assets to its `Selected Objects` list.
+2.  **Create `SelectionData B` (Object-based):**
+    *   Name: "Ignored Character Models"
+    *   Manually add any character models you want to exclude (e.g., old versions, test models) to its `Selected Objects` list.
+3.  **Create a Combined SelectionData:**
+    *   In the **SelectionData Window**, click **"New Combined..."**.
+    *   **Name/Description:** "Final Character Models"
+    *   **Operation:** `Difference`
+    *   **Mode:** `Dynamic` (so it updates if you change A or B)
+    *   **Sources:**
+        *   Add `SelectionData A` ("All Character Models") as the first source.
+        *   Add `SelectionData B` ("Ignored Character Models") as the second source.
+    *   Click "Create Combined SelectionData".
+4.  Now, the "Final Character Models" SelectionData will always represent the models in A minus any models also present in B.
+
+## 5. Notes and Tips
+
+*   The `Description` field of a SelectionData asset is primarily used for display in the SelectionData Window. The actual asset filename can be different.
+*   When creating combined selections, be mindful of cycles (e.g., Data A uses Data B as a source, and Data B uses Data A). The tool has cycle detection to prevent infinite loops, but it's good practice to design your combinations logically.
+*   The `ExecuteUnitySearchQuery` method in `SelectionData.cs` is a simplified search. For very complex asset queries, Unity's built-in Search window might be more powerful, but you can then save those results into an object-based SelectionData.
+*   Deleting a SelectionData asset that is used as a source in another *dynamic* combined SelectionData will cause the combined one to miss those objects. For *static* combined selections, the objects are already cached.
+*   Use the "Starred" feature to keep your most important or frequently used selections at the top of the list in the SelectionData Window.
+
+This concludes the overview of the SelectionData tool.

--- a/Assets/ExtEditor/Editor/SelectionDataEditor/Documentation/SelectionData_Usage_JA.md
+++ b/Assets/ExtEditor/Editor/SelectionDataEditor/Documentation/SelectionData_Usage_JA.md
@@ -1,0 +1,156 @@
+# (日本語訳) ExtEditor - SelectionData ツール利用ガイド
+
+## 1. 概要
+
+The SelectionData tool allows you to save, manage, and reuse selections of objects (both assets from the Project window and GameObjects from the Scene). You can create simple selections by manually adding objects, define selections using search queries, or build complex selections by combining other SelectionData assets.
+
+This is particularly useful for:
+- Quickly re-selecting frequently used groups of assets or GameObjects.
+- Managing complex sets of objects for batch operations or exports.
+- Creating dynamic collections of assets that update based on search criteria or other linked selections.
+
+The tool consists of three main parts:
+*   **SelectionData Assets:** ScriptableObjects that store the definition of your selections.
+*   **SelectionData Inspector:** A custom inspector for viewing and editing SelectionData assets.
+*   **SelectionData Window:** A dedicated editor window for browsing, creating, managing, and applying your saved SelectionData assets.
+
+## 2. SelectionData アセット
+
+A SelectionData asset (`.asset` file) holds the information about a specific selection.
+
+### SelectionData アセットの作成:
+
+You can create SelectionData assets in several ways:
+*   **From the SelectionData Window:** (Recommended)
+    *   Open the window via `Tools > ExtEditor > Selection Data Window`.
+    *   Click "New Object-based", "New Query-based", or "New Combined..."
+*   **From the Project Context Menu:**
+    *   Right-click in the Project window and select `Create > ExtEditor > Selection Data`. This creates a basic, empty object-based SelectionData asset.
+
+### 主なプロパティ (インスペクターで表示):
+
+When you select a SelectionData asset, its Inspector will show the following:
+
+*   **Description:** A user-friendly name or description for this saved selection. This is what appears in the SelectionData Window.
+*   **Is Starred:** Check this to mark the selection as a "favorite". Starred items appear at the top of the list in the SelectionData Window.
+*   **Selection Mode:**
+    *   **Objects:** The selection is defined by a direct list of objects.
+    *   **Query:** The selection is defined by a Unity Search query string.
+*   **Selected Objects (appears if Mode is `Objects`):**
+    *   A list where you can drag and drop assets or GameObjects.
+    *   If this SelectionData is a *dynamic* combined selection, this list is read-only and shows the dynamically generated objects.
+*   **Unity Search Query (appears if Mode is `Query`):**
+    *   A text field for your search query (e.g., `t:Texture`, `Player`, `l:MyLabel`).
+    *   The query uses a simplified version of Unity's search capabilities, primarily focusing on `AssetDatabase.FindAssets`.
+*   **Combine Selection (Header):** Settings for combining other SelectionData assets.
+    *   **Source Selection Data:** A list where you can add other SelectionData assets to be combined.
+    *   **Combination Mode (if Sources are present):**
+        *   **Static:** The `Selected Objects` list is populated once from the source SelectionData assets when the sources or mode change. The selection then behaves like a regular `Objects` mode selection and does not update automatically if the sources change later.
+        *   **Dynamic:** The `Selected Objects` are re-evaluated from the source SelectionData assets every time the selection is applied or its effective objects are requested. This means changes in the source selections will be reflected automatically.
+    *   **Combine Operation (if Sources are present):**
+        *   **Union:** Includes all unique objects from all source SelectionData assets.
+        *   **Intersection:** Includes only objects that are present in *all* source SelectionData assets.
+        *   **Difference:** Includes objects from the first source SelectionData asset that are *not* present in any of the subsequent source assets.
+
+### インスペクターでの操作:
+
+*   **Apply Stored Selection:** Sets your current editor selection (in Project and Hierarchy windows) to the objects defined by this SelectionData asset.
+*   **Set Selection From Current Editor Selection:** (Only for non-combined, `Objects` mode) Clears the `Selected Objects` list and populates it with the objects currently selected in your editor.
+*   **Test Query & Select Results:** (For `Query` mode) Executes the query and selects the found objects in the editor.
+*   **Cache Dynamic Selection to Static List:** (For *dynamic* combined selections) Calculates the objects from its dynamic sources and stores them in the local `Selected Objects` list. This is useful if you want to "bake" a dynamic selection. Note: you might also want to change `Combination Mode` to `Static` if you don't want it to re-evaluate later.
+
+## 3. SelectionData ウィンドウ (`ツール > ExtEditor > Selection Data ウィンドウ`)
+
+This window is the central hub for managing your SelectionData assets.
+
+### ツールバー:
+
+*   **New Object-based:** Creates a new SelectionData asset set to `Objects` mode. If you have objects selected in the editor, they will be automatically added to the new asset's `Selected Objects` list.
+*   **New Query-based:** Creates a new SelectionData asset set to `Query` mode.
+*   **New Combined...:** Opens a popup dialog to create a new SelectionData asset that combines other existing SelectionData assets.
+    *   **Name/Description:** Name for the new combined asset.
+    *   **Operation:** `Union`, `Intersection`, or `Difference`.
+    *   **Mode:** `Static` or `Dynamic`.
+    *   **Source SelectionData Assets:** Add slots and drag other SelectionData assets here.
+*   **Search Bar:** Filters the list of SelectionData assets by their name or description.
+*   **Refresh Button:** Rescans the project for SelectionData assets.
+
+### SelectionData リスト (左ペイン):
+
+*   Displays all SelectionData assets in your project.
+*   **Starred (★):** Starred items appear first.
+*   **Type Indicator:**
+    *   `[O]`: Object-based
+    *   `[Q]`: Query-based
+    *   `[C]`: Combined
+*   **Name/Description:** Click to select and view details in the right pane.
+*   **Actions per item:**
+    *   **Apply:** Sets your current editor selection to this SelectionData asset.
+    *   **Edit Icon (pencil):** Selects the asset in the Project window, allowing you to edit its properties in the main Inspector.
+    *   **Dup:** Duplicates the selected SelectionData asset.
+    *   **Delete Icon (trash can):** Deletes the SelectionData asset (with confirmation).
+
+### 詳細ビュー (右ペイン):
+
+When you select a SelectionData asset from the list:
+*   **Name/Desc:** The description of the selected item.
+*   **Starred:** A toggle to change its starred status (changes are saved immediately).
+*   **Type:** `Objects` or `Query`.
+*   **Combination Info:** If it's a combined selection, shows the operation, mode, and lists its sources.
+*   **Query:** If it's a query-based selection, shows the query string.
+*   **Effective Objects:** Lists all the actual `UnityEngine.Object`s that this SelectionData asset currently resolves to.
+    *   You can click on an object in this list to ping it in the Project/Hierarchy.
+    *   **Select Only:** Selects *only* that specific object in the editor.
+
+## 4. 利用例
+
+### 例1: よく使うプレハブのセレクションを保存する
+
+1.  In the Project window, manually select several Prefab assets you use often.
+2.  Open the **SelectionData Window** (`Tools > ExtEditor > Selection Data Window`).
+3.  Click **"New Object-based"** in the toolbar.
+4.  A new SelectionData asset will be created, and its `Selected Objects` list will be automatically populated with your currently selected Prefabs.
+5.  Give it a meaningful **Description** in its Inspector (e.g., "Core UI Prefabs").
+6.  You can now quickly re-select these prefabs by finding this item in the SelectionData Window and clicking "Apply".
+
+### 例2: 全てのテクスチャアセットの動的セレクションを作成する
+
+1.  Open the **SelectionData Window**.
+2.  Click **"New Query-based"**.
+3.  Select the newly created SelectionData asset in the Project window to view its Inspector.
+4.  Set its **Description** (e.g., "All Project Textures").
+5.  In the **Unity Search Query** field, type `t:Texture`.
+6.  Click **"Test Query & Select Results"** to see it in action.
+7.  Now, whenever you "Apply" this SelectionData from the window, it will select all Texture assets currently in your project.
+
+### 例3: セレクションの組み合わせ - 無視するモデルを除いた全てのキャラクターモデル
+
+1.  **Create `SelectionData A` (Object-based):**
+    *   Name: "All Character Models"
+    *   Manually add all your character model assets to its `Selected Objects` list.
+2.  **Create `SelectionData B` (Object-based):**
+    *   Name: "Ignored Character Models"
+    *   Manually add any character models you want to exclude (e.g., old versions, test models) to its `Selected Objects` list.
+3.  **Create a Combined SelectionData:**
+    *   In the **SelectionData Window**, click **"New Combined..."**.
+    *   **Name/Description:** "Final Character Models"
+    *   **Operation:** `Difference`
+    *   **Mode:** `Dynamic` (so it updates if you change A or B)
+    *   **Sources:**
+        *   Add `SelectionData A` ("All Character Models") as the first source.
+        *   Add `SelectionData B` ("Ignored Character Models") as the second source.
+    *   Click "Create Combined SelectionData".
+4.  Now, the "Final Character Models" SelectionData will always represent the models in A minus any models also present in B.
+
+## 5. 注意点とヒント
+
+*   The `Description` field of a SelectionData asset is primarily used for display in the SelectionData Window. The actual asset filename can be different.
+*   When creating combined selections, be mindful of cycles (e.g., Data A uses Data B as a source, and Data B uses Data A). The tool has cycle detection to prevent infinite loops, but it's good practice to design your combinations logically.
+*   The `ExecuteUnitySearchQuery` method in `SelectionData.cs` is a simplified search. For very complex asset queries, Unity's built-in Search window might be more powerful, but you can then save those results into an object-based SelectionData.
+*   Deleting a SelectionData asset that is used as a source in another *dynamic* combined SelectionData will cause the combined one to miss those objects. For *static* combined selections, the objects are already cached.
+*   Use the "Starred" feature to keep your most important or frequently used selections at the top of the list in the SelectionData Window.
+
+以上が SelectionData ツールの概要です。
+
+---
+*このドキュメントは英語版を元に翻訳されました。*


### PR DESCRIPTION
I created English and Japanese markdown documentation for the SelectionData tool, located in Assets/ExtEditor/Editor/SelectionDataEditor/Documentation/.

The documentation covers:
- Overview of the SelectionData tool.
- Explanation of SelectionData ScriptableObjects and their properties.
- Usage of the custom Inspector for SelectionData assets.
- Features and usage of the SelectionData Window.
- Examples for creating object-based, query-based, and combined selections.

The Japanese version is a simulated translation of the English content, primarily translating headers and structure.