### PR TITLE
Add GradientTexture drawer

### DIFF
--- a/Assets/ExtEditor/Editor/UberMaterialPropertyDrawer/Editor/GradientTextureData.cs
+++ b/Assets/ExtEditor/Editor/UberMaterialPropertyDrawer/Editor/GradientTextureData.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+namespace ExtEditor.UberMaterialPropertyDrawer
+{
+    public class GradientTextureData : ScriptableObject
+    {
+        public Gradient gradient = new Gradient();
+        [HideInInspector] public Texture2D texture;
+    }
+}

--- a/Assets/ExtEditor/Editor/UberMaterialPropertyDrawer/Editor/GradientTextureDrawer.cs
+++ b/Assets/ExtEditor/Editor/UberMaterialPropertyDrawer/Editor/GradientTextureDrawer.cs
@@ -1,0 +1,107 @@
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace ExtEditor.UberMaterialPropertyDrawer
+{
+    public class GradientTextureDrawer : MaterialPropertyDrawer
+    {
+        private int _size = 256;
+        private bool _half = false;
+
+        public GradientTextureDrawer() { }
+
+        public GradientTextureDrawer(string args)
+        {
+            if (string.IsNullOrEmpty(args)) return;
+            var tokens = args.Split(',');
+            if (tokens.Length > 0) int.TryParse(tokens[0], out _size);
+            if (tokens.Length > 1) _half = tokens[1].Trim().ToLowerInvariant().StartsWith("h");
+        }
+
+        public override float GetPropertyHeight(MaterialProperty prop, string label, MaterialEditor editor)
+        {
+            const int lines = 2;
+            return EditorGUIUtility.singleLineHeight * lines + 4;
+        }
+
+        public override void OnGUI(Rect position, MaterialProperty prop, GUIContent label, MaterialEditor editor)
+        {
+            if (prop.type != MaterialProperty.PropType.Texture)
+            {
+                EditorGUI.LabelField(position, "GradientTexture used on non-texture property");
+                return;
+            }
+
+            var mat = editor.target as Material;
+            if (mat == null) return;
+
+            var path = AssetDatabase.GetAssetPath(mat);
+            var subAssets = AssetDatabase.LoadAllAssetsAtPath(path);
+            var dataName = prop.name + "_GradientData";
+            var data = subAssets.OfType<GradientTextureData>().FirstOrDefault(a => a.name == dataName);
+            if (data == null)
+            {
+                data = ScriptableObject.CreateInstance<GradientTextureData>();
+                data.name = dataName;
+                AssetDatabase.AddObjectToAsset(data, mat);
+                AssetDatabase.ImportAsset(path);
+                subAssets = AssetDatabase.LoadAllAssetsAtPath(path);
+            }
+
+            EditorGUI.BeginChangeCheck();
+            var line = new Rect(position.x, position.y, position.width, EditorGUIUtility.singleLineHeight);
+            data.gradient = EditorGUI.GradientField(line, label.text, data.gradient);
+            line.y += line.height + 2;
+
+            EditorGUI.BeginDisabledGroup(true);
+            editor.TextureProperty(line, prop, label.text, false);
+            EditorGUI.EndDisabledGroup();
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                var tex = BakeTexture(data);
+                tex.name = prop.name + "_GradientTex";
+                if (!subAssets.Contains(tex))
+                    AssetDatabase.AddObjectToAsset(tex, mat);
+                AssetDatabase.ImportAsset(path);
+                data.texture = tex;
+                prop.textureValue = tex;
+                EditorUtility.SetDirty(data);
+                EditorUtility.SetDirty(tex);
+                EditorUtility.SetDirty(mat);
+                AssetDatabase.SaveAssets();
+            }
+
+            if (prop.textureValue != data.texture && data.texture != null)
+            {
+                AssetDatabase.RemoveObjectFromAsset(data.texture);
+                Object.DestroyImmediate(data.texture, true);
+                data.texture = null;
+                EditorUtility.SetDirty(data);
+                AssetDatabase.ImportAsset(path);
+                AssetDatabase.SaveAssets();
+            }
+        }
+
+        private Texture2D BakeTexture(GradientTextureData data)
+        {
+            var format = _half ? TextureFormat.RGBAHalf : TextureFormat.RGBA32;
+            var tex = data.texture;
+            if (tex == null || tex.width != _size || tex.format != format)
+            {
+                tex = new Texture2D(_size, 1, format, false, true);
+            }
+
+            var colors = new Color[_size];
+            for (int i = 0; i < _size; i++)
+            {
+                float t = (float)i / (_size - 1);
+                colors[i] = data.gradient.Evaluate(t);
+            }
+            tex.SetPixels(colors);
+            tex.Apply();
+            return tex;
+        }
+    }
+}

--- a/Assets/ExtEditor/Editor/UberMaterialPropertyDrawer/Editor/UberDrawer.cs
+++ b/Assets/ExtEditor/Editor/UberMaterialPropertyDrawer/Editor/UberDrawer.cs
@@ -34,6 +34,7 @@ namespace ExtEditor.UberMaterialPropertyDrawer
             else if (drawer == "Vector2")     this._propertyDrawer = new Vector2Drawer(groupName);
             else if (drawer == "Vector3")     this._propertyDrawer = new Vector3Drawer(groupName);
             else if (drawer == "CurveTexture") this._propertyDrawer = new CurveTextureDrawer();
+            else if (drawer == "GradientTexture") this._propertyDrawer = new GradientTextureDrawer();
             else if (drawer == "Init")        
             {
                 GroupExpanded.Clear();
@@ -49,6 +50,7 @@ namespace ExtEditor.UberMaterialPropertyDrawer
             this._propertyDrawer = null;
             if (drawer == "Enum") this._propertyDrawer = new UberEnumDrawer(groupName, arg0);
             else if (drawer == "CurveTexture") this._propertyDrawer = new CurveTextureDrawer(arg0);
+            else if (drawer == "GradientTexture") this._propertyDrawer = new GradientTextureDrawer(arg0);
         }
         
         public UberDrawer(string groupName, string drawer, string[] enumNames, float[] vals)

--- a/Assets/ExtEditor/Editor/UberMaterialPropertyDrawer/README_EN.md
+++ b/Assets/ExtEditor/Editor/UberMaterialPropertyDrawer/README_EN.md
@@ -25,7 +25,9 @@ The system is primarily driven by the `UberDrawer` class, which acts as a dispat
     -   These ensure consistent layout within groups.
 -   **Curve Texture Drawer:**
     -   `[Uber(GroupName, CurveTexture, size,mode,precision)]`: Shows up to four `AnimationCurve` fields and bakes them into a texture stored as a sub-asset of the material. `size` is the texture width, `mode` is `value` or `cumulative`, and `precision` is `8bit` or `half`.
--   **Property Visibility:**
+    -   **Gradient Texture Drawer:**
+    -   `[Uber(GroupName, GradientTexture, size,precision)]`: Displays a `Gradient` field and bakes it into a texture stored as a sub-asset of the material. `size` sets the texture width and `precision` is `8bit` or `half`.
+    -   **Property Visibility:**
     -   Standard material properties tagged with `[Uber(GroupName)]` are drawn using the default property drawer but are only visible if `GroupName` (and all its parent groups, if nested) are expanded.
 -   **Nesting:** Groups can be nested within other groups to create deeper hierarchies.
 -   **State Initialization:**
@@ -93,7 +95,12 @@ Then in the shader:
     [Uber(Curves, CurveTexture, 256,cumulative,half)] _CurveTex ("Curve Texture", 2D) = "white" {}
 ```
 
-**7. Nesting Groups:**
+**7. Baking Gradients to a Texture:**
+```shaderlab
+    [Uber(Curves, GradientTexture, 256,half)] _GradientTex ("Gradient Texture", 2D) = "white" {}
+```
+
+**8. Nesting Groups:**
 Simply define a `BeginGroup` within another active group.
 ```shaderlab
     [Uber(Parent, BeginGroup)] _ParentFoldout ("Parent Group", Int) = 0

--- a/Assets/ExtEditor/Editor/UberMaterialPropertyDrawer/README_JP.md
+++ b/Assets/ExtEditor/Editor/UberMaterialPropertyDrawer/README_JP.md
@@ -25,6 +25,8 @@ Uber Material Property Drawerは、Unityで高度にカスタマイズされ整�
     -   これらはグループ内での一貫したレイアウトを保証します。
 -   **カーブテクスチャドロワー:**
     -   `[Uber(GroupName, CurveTexture, size,mode,precision)]`: 最大4つの`AnimationCurve`を入力し、テクスチャにベイクしてマテリアルのサブアセットとして保持します。`size`はテクスチャ幅、`mode`は`value`または`cumulative`、`precision`は`8bit`または`half`を指定します。
+-   **グラデーションテクスチャドロワー:**
+    -   `[Uber(GroupName, GradientTexture, size,precision)]`: `Gradient`を入力し、テクスチャにベイクしてマテリアルのサブアセットとして保持します。`size`はテクスチャ幅、`precision`は`8bit`または`half`を指定します。
 -   **プロパティの可視性:**
     -   `[Uber(GroupName)]`でタグ付けされた標準のマテリアルプロパティは、デフォルトのプロパティドロワーを使用して描画されますが、`GroupName`（およびネストされている場合はすべての親グループ）が展開されている場合にのみ表示されます。
 -   **ネスティング:** グループを他のグループ内にネストして、より深い階層を作成できます。
@@ -93,7 +95,12 @@ public enum MyBlendMode { Alpha, Additive, Multiply }
     [Uber(Curves, CurveTexture, 256,cumulative,half)] _CurveTex ("Curve Texture", 2D) = "white" {}
 ```
 
-**7. グループのネスティング:**
+**7. グラデーションのベイク:**
+```shaderlab
+    [Uber(Curves, GradientTexture, 256,half)] _GradientTex ("Gradient Texture", 2D) = "white" {}
+```
+
+**8. グループのネスティング:**
 アクティブなグループ内にもう一つの`BeginGroup`を定義するだけです。
 ```shaderlab
     [Uber(Parent, BeginGroup)] _ParentFoldout ("Parent Group", Int) = 0


### PR DESCRIPTION
## Summary
- support GradientTexture in UberDrawer to bake Gradient into subasset
- add GradientTexture drawer implementation
- document GradientTexture drawer in README (EN/JP)

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684542c8936883329a30f1861de2497a