### PR TITLE
Use EditorUtility.RevealInFinder for opening folders

### DIFF
--- a/Assets/ExtEditor/Editor/CaptureWindow/CaptureWindow.cs
+++ b/Assets/ExtEditor/Editor/CaptureWindow/CaptureWindow.cs
@@ -223,8 +223,7 @@ namespace ExtEditor.Editor.CaptureWindow
         {
             string fullPath = Path.Combine(Application.dataPath, outputDirectory.Replace("Assets/", ""));
             Directory.CreateDirectory(fullPath);
-            // EditorUtility.RevealInFinder(fullPath);
-            System.Diagnostics.Process.Start(fullPath);
+            EditorUtility.RevealInFinder(fullPath);
         }
     }
 }

--- a/Assets/ExtEditor/Editor/ExportPackageConfig/ExportPackageConfig.cs
+++ b/Assets/ExtEditor/Editor/ExportPackageConfig/ExportPackageConfig.cs
@@ -193,7 +193,7 @@ namespace ExtEditor.Editor.ExportPackageConfig
                     // 出力先のディレクトリを作成
                    config.MakeDirectoryIfNotExists(config.ExportFilePath());
                    var directoryName = Path.GetDirectoryName(config.ExportFilePath());
-                    System.Diagnostics.Process.Start("explorer.exe", directoryName);
+                    EditorUtility.RevealInFinder(directoryName);
                 }
                 
                 EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(config.includeDependencies)), new GUIContent("依存アセットを含める"));


### PR DESCRIPTION
## Summary
- use Unity's `EditorUtility.RevealInFinder` in CaptureWindow for opening the output folder
- use the same method in ExportPackageConfig when showing the export directory

## Testing
- `echo 'No tests defined'`

------
https://chatgpt.com/codex/tasks/task_e_6846ed3cf9bc833287d9badc9fd95bf7