### PR TITLE
Allow customizable CaptureWindow shortcut

### DIFF
--- a/Assets/ExtEditor/Editor/CaptureWindow/CaptureWindow.cs
+++ b/Assets/ExtEditor/Editor/CaptureWindow/CaptureWindow.cs
@@ -1,4 +1,5 @@
 using UnityEditor;
+using UnityEditor.ShortcutManagement;
 using UnityEngine;
 using System;
 using System.IO;
@@ -7,8 +8,9 @@ using System.Collections.Generic;
 
 namespace ExtEditor.Editor.CaptureWindow
 {
-	public class CaptureWindow : EditorWindow
+    public class CaptureWindow : EditorWindow
     {
+        private static CaptureWindow lastInstance;
         private enum CaptureSource
         {
             GameView,
@@ -34,6 +36,7 @@ namespace ExtEditor.Editor.CaptureWindow
 
         private void OnEnable()
         {
+            lastInstance = this;
             UpdateSceneCameras();
             
             // MainCameraを探す
@@ -47,6 +50,14 @@ namespace ExtEditor.Editor.CaptureWindow
 
             // 選択中のカメラのインデックスを設定
             selectedCameraIndex = System.Array.IndexOf(sceneCamera, captureCamera);
+        }
+
+        private void OnDisable()
+        {
+            if (lastInstance == this)
+            {
+                lastInstance = null;
+            }
         }
 
         private void UpdateSceneCameras()
@@ -224,6 +235,22 @@ namespace ExtEditor.Editor.CaptureWindow
             string fullPath = Path.Combine(Application.dataPath, outputDirectory.Replace("Assets/", ""));
             Directory.CreateDirectory(fullPath);
             EditorUtility.RevealInFinder(fullPath);
+        }
+
+        [MenuItem("Tools/CaptureWindow/Capture & Save")]
+        [Shortcut("ExtEditor/CaptureWindow/Capture & Save", KeyCode.F9, ShortcutModifiers.Action | ShortcutModifiers.Shift)]
+        private static void CaptureAndSaveShortcut()
+        {
+            if (lastInstance != null)
+            {
+                lastInstance.CaptureAndSave();
+                return;
+            }
+
+            var temp = CreateInstance<CaptureWindow>();
+            temp.OnEnable();
+            temp.CaptureAndSave();
+            DestroyImmediate(temp);
         }
     }
 }

--- a/Assets/ExtEditor/Editor/CaptureWindow/README_EN.md
+++ b/Assets/ExtEditor/Editor/CaptureWindow/README_EN.md
@@ -49,6 +49,7 @@ The Capture Window is a Unity editor tool designed to take screenshots from vari
 
 3.  **Perform Capture:**
     *   Click the **"Capture and Save PNG"** button.
+    *   By default, press **Ctrl+Shift+F9** (`Tools > CaptureWindow > Capture & Save`) to grab a screenshot without opening the window. This shortcut can be changed in Unity's Shortcut Manager.
     *   The image will be rendered based on your settings and saved to the specified `Output Directory`.
     *   A confirmation message, including the file path, will be logged in the Unity Console.
 

--- a/Assets/ExtEditor/Editor/CaptureWindow/README_JP.md
+++ b/Assets/ExtEditor/Editor/CaptureWindow/README_JP.md
@@ -49,6 +49,7 @@
 
 3.  **キャプチャの実行:**
     *   **"Capture and Save PNG"** ボタンをクリックします。
+    *   また、`Tools > CaptureWindow > Capture & Save` （デフォルトのショートカット: **Ctrl+Shift+F9**）からウィンドウを開かずに実行することもできます。ショートカットは Unity の Shortcut Manager から変更できます。
     *   設定に基づいて画像がレンダリングされ、指定された `Output Directory` に保存されます。
     *   ファイルパスを含む確認メッセージがUnityコンソールに記録されます。
 


### PR DESCRIPTION
## Summary
- register Capture & Save shortcut using `UnityEditor.ShortcutManagement.Shortcut`
- mention customisable shortcut in both English and Japanese guides
- fix indentation for `CaptureWindow` class declaration

## Testing
- `pytest -q` *(no tests ran)*
- `npm test` *(failed to find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846feea80a483328b143d9de09f7f48